### PR TITLE
Add KEY_DETAILS to possible queries

### DIFF
--- a/borgbase_api_client/queries.py
+++ b/borgbase_api_client/queries.py
@@ -10,3 +10,18 @@ query repoList {
   }
 }
 '''
+ 
+KEY_DETAILS = '''
+query repoList {
+  sshList {
+    id
+    name
+    keyData
+    keyType
+    bits
+    comment
+    hashMd5
+    addedAt
+  }
+}
+'''


### PR DESCRIPTION
Add the missing sshList API call to the query list.

As I mentioned in the issue #1 I am creating an Ansible module to automate the creation of borgbase repositories. I need this query to reuse already added SSH keys.

Thanks.