### PR TITLE
Add basic setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+__pycache__

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+import setuptools
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="borgbase-api-client",
+    version="0.0.1",
+    author="Borgbase",
+    author_email="hello@borgbase.com",
+    description="GraphQL client to execute operations against your BorgBase.com account.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/borgbase/borgbase-api-client",
+    install_requires=[
+        "requests>=2.21.0"
+    ],
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Topic :: System :: Archiving :: Backup"
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)


### PR DESCRIPTION
This will allow the project to be easily installed in other projects,
even if it isn't published to pypi.

For example, in requirements.txt one could add:

`-e
git://github.com/borgbase/borgbase-api-client.git#egg=borgbase-api-client`

I chose the requests version >= 2.21.0 because that is what is currently available in debian stable.