### PR TITLE
Use non-nullable types for repoAdd name and region, fix #7

### DIFF
--- a/borgbase_api_client/mutations.py
+++ b/borgbase_api_client/mutations.py
@@ -38,13 +38,13 @@ mutation sshAdd(
 
 REPO_ADD = """
 mutation repoAdd(
-  $name: String
+  $name: String!
   $quota: Int
   $quotaEnabled: Boolean
   $appendOnlyKeys: [String]
   $fullAccessKeys: [String]
   $alertDays: Int
-  $region: String
+  $region: String!
   $borgVersion: String
   ) {
     repoAdd(


### PR DESCRIPTION
Apparently there is a mismatch in types concerning the repoAdd mutation for the GraphQL API running at borgbase and the current version of the client.
This PR fixes the types by switching from nullable `String` to non-nullable `String!` for the fields `name` and `region`

This fixes #7 